### PR TITLE
With :change-only option, only notify when status changes.

### DIFF
--- a/autoexpect/src/leiningen/autoexpect.clj
+++ b/autoexpect/src/leiningen/autoexpect.clj
@@ -23,7 +23,7 @@
   [project & args]
   (let [should-growl (some #{:growl ":growl" "growl"} args)
         should-notify (some #{:notify ":notify" "notify"} args)
-        change-only (some #{:notify ":change-only" "change-only"} args)]
+        change-only (some #{:change-only ":change-only" "change-only"} args)]
     (eval/eval-in-project
      (add-deps project)
      `(autoexpect.runner/monitor-project :should-growl ~should-growl :should-notify ~should-notify :change-only ~change-only)

--- a/autoexpect/src/leiningen/autoexpect.clj
+++ b/autoexpect/src/leiningen/autoexpect.clj
@@ -22,8 +22,9 @@
   Reports results to growl and STDOUT."
   [project & args]
   (let [should-growl (some #{:growl ":growl" "growl"} args)
-        should-notify (some #{:notify ":notify" "notify"} args)]
+        should-notify (some #{:notify ":notify" "notify"} args)
+        change-only (some #{:notify ":change-only" "change-only"} args)]
     (eval/eval-in-project
      (add-deps project)
-     `(autoexpect.runner/monitor-project :should-growl ~should-growl :should-notify ~should-notify)
+     `(autoexpect.runner/monitor-project :should-growl ~should-growl :should-notify ~should-notify :change-only ~change-only)
      `(require 'autoexpect.runner))))


### PR DESCRIPTION
The notifications can be distracting. Would prefer to only
have them when tests actually change status. This allows
that with the extra option :change-only.